### PR TITLE
Update regex for modern commandbox

### DIFF
--- a/index.js
+++ b/index.js
@@ -81,7 +81,7 @@ function sendCommandToBox(cmd) {
 }
 
 function watchForBoxInitialization(output) {
-  if (!boxInitialized && output.toString().match(/CommandBox> $/)) {
+  if (!boxInitialized && output.toString().match(/CommandBox[>:]/)) {
     boxInitialized = true;
     console.info(`box is initialized and ready for input`);
     box.stdout.on("data", returnOutput);


### PR DESCRIPTION
Modern versions of commandbox use `CommandBox:{folder}>` for prefix.